### PR TITLE
Block students after adding them to site

### DIFF
--- a/.github/workflows/add-cws-users-to-azqs-site.yml
+++ b/.github/workflows/add-cws-users-to-azqs-site.yml
@@ -71,4 +71,5 @@ jobs:
           terminus drush "${{ inputs.pantheon_site_name }}"."${{ inputs.pantheon_environment }}" -- cas:set-cas-username "${USER}" "${USER}" </dev/null
           terminus drush "${{ inputs.pantheon_site_name }}"."${{ inputs.pantheon_environment }}" -- user:role:add "az_content_editor" "${USER}" </dev/null
           terminus drush "${{ inputs.pantheon_site_name }}"."${{ inputs.pantheon_environment }}" -- user:role:add "az_content_admin" "${USER}" </dev/null
+          terminus drush "${{ inputs.pantheon_site_name }}"."${{ inputs.pantheon_environment }}" -- user:block "${USER}" </dev/null
         done < students.txt


### PR DESCRIPTION
I noticed that student worker accounts are still active after they are added to sites even though fulltime staff are blocked, so this should fix that bug.